### PR TITLE
Fix off-by-one error for empty strings

### DIFF
--- a/jsonlib.cpp
+++ b/jsonlib.cpp
@@ -78,7 +78,7 @@ String jsonExtract(String json, String name){
   if(next == '\"'){
     //Serial.println(".. a string");
     start = start + 1;
-    stop = json.indexOf('"', start + 1);
+    stop = json.indexOf('"', start);
   }
   else if(next == '['){
     //Serial.println(".. a list");


### PR DESCRIPTION
Previously parsing this would break: {"key":""}
jsonExtract("{\"key\":\"\"}", "key")  -> "\"}"