### PR TITLE
Work around Arduino's non std Strings library implementation

### DIFF
--- a/jsonlib.cpp
+++ b/jsonlib.cpp
@@ -69,7 +69,7 @@ String jsonIndexList(String json, int idx){
 // return a sub-json struct
 String jsonExtract(String json, String name){
   char next;
-  int start, stop;
+  int start = 0, stop = 0;
   static const size_t npos = -1;
   
   name = String("\"") + name + String("\"");
@@ -112,7 +112,7 @@ String jsonExtract(String json, String name){
   else if(next == '.' || next == '-' || ('0' <= next  && next <= '9')){
     //Serial.println(".. a number");
     int i = start;
-    while(i++ < json.length() && json.charAt(i) == '.' || ('0' <= json.charAt(i)  && json.charAt(i) <= '9')){
+    while(i++ < json.length() && (json.charAt(i) == '.' || ('0' <= json.charAt(i)  && json.charAt(i) <= '9'))){
     }
     stop = i;
   }

--- a/jsonlib.cpp
+++ b/jsonlib.cpp
@@ -70,9 +70,10 @@ String jsonIndexList(String json, int idx){
 String jsonExtract(String json, String name){
   char next;
   int start, stop;
+  static const size_t npos = -1;
   
   name = String("\"") + name + String("\"");
-  if (json.indexOf(name) == std::string::npos) return json.substring(0,0);
+  if (json.indexOf(name) == npos) return json.substring(0,0);
   start = json.indexOf(name) + name.length() + 1;
   next = json.charAt(start);
   if(next == '\"'){


### PR DESCRIPTION
My original PR for empty strings (#2) assumes that the strings library provides [`std::string::npos`](https://www.cplusplus.com/reference/string/string/npos/), but the non-standard 'light' implementation of the strings class in Arduino does not provide this. Causing errors like:
```
/home/me/Arduino/libraries/jsonlib/jsonlib.cpp: In function 'String jsonExtract(String, String)':
/home/me/Arduino/libraries/jsonlib/jsonlib.cpp:75:34: error: 'std::string' has not been declared
   if (json.indexOf(name) == std::string::npos) return json.substring(0,0);
                                  ^~~~~~
exit status 1
Error compiling for board Arduino Uno.
```
This came to light for me when testing the upcoming major revision of the esp32 core (2.0.0-alpha), which now provides the Arduino-alike implementation of the strings lib (the current esp32-1.0.6 implementation uses a standard strings lib and still compiles OK).

Apologies for not testing the original PR more widely.