### PR TITLE
Added boolean and null according to the definition of JSON

### DIFF
--- a/examples/json_org/json_org.ino
+++ b/examples/json_org/json_org.ino
@@ -17,7 +17,8 @@ String json = String(
 "                        \"para\": \"A meta-markup language, used to create markup languages such as DocBook.\","
 "						\"GlossSeeAlso\": [\"GML\", \"XML\"]"
 "                    },"
-"					\"GlossSee\": \"markup\""
+"					\"GlossSee\": \"markup\","
+"					\"IsAvailable\": false"
 "                }"
 "            }"
 "        }"
@@ -33,6 +34,8 @@ void setup(){
   String glossdiv = jsonExtract(glossary, "GlossDiv");
   String glossentry = jsonExtract(glossdiv, "GlossEntry");
   String glossterm = jsonExtract(glossentry, "GlossTerm");
+  bool isAvailable = jsonExtract(glossentry, "IsAvailable") == "true";
+	
   Serial.print("GlossTerm:");
   Serial.println(glossterm);
 }

--- a/jsonlib.cpp
+++ b/jsonlib.cpp
@@ -77,6 +77,12 @@ String jsonExtract(const String& json, const String& nameArg){
   if (json.indexOf(name) == npos) return json.substring(0,0);
   start = json.indexOf(name) + name.length() + 1;
   next = json.charAt(start);
+  
+  while(start < json.length() && next == ' ') { // filters blanks before value if there
+    start++;
+    next = json.charAt(start);
+  }
+  
   if(next == '\"'){
     //Serial.println(".. a string");
     start = start + 1;
@@ -110,6 +116,45 @@ String jsonExtract(const String& json, const String& nameArg){
     }
     stop = i + 1;
   }
+  else if(next == 't'){
+	//Serial.println("... a boolean true");
+	int i = start;
+	
+	while(i++ < json.length()){
+		if(json.charAt(i) == 't' && json.charAt(i + 1) == 'r' && json.charAt(i + 2) == 'u' && json.charAt(i + 3) == 'e')
+		{
+			stop = i + 3;
+			break;
+		}
+		else if (json.charAt(i) == ',' || json.charAt(i) == '}' || json.charAt(i) == ']' || json.charAt(i) == ']') {
+			stop = i;
+			break;
+		}
+	}
+  } 
+  else if(next == 'f' ){
+	//Serial.println("... a boolean false");
+    int i = start;
+	
+	if(json.charAt(i) == 'f' && json.charAt(i + 1) == 'a' && json.charAt(i + 2) == 'l' && json.charAt(i + 3) == 's' && json.charAt(i + 4) == 'e')
+	{
+		stop = i + 4;
+	}
+	else {
+		stop = i;
+	}	
+  } 
+  else if(next == 'n' ){
+	//Serial.println("... a null");
+    int i = start;
+	if(json.charAt(i) == 'n' && json.charAt(i + 1) == 'u' && json.charAt(i + 2) == 'l' && json.charAt(i + 3) == 'l')
+	{
+		stop = i + 3;
+	}
+	else {
+		stop = i;
+	}
+  }  
   else if(next == '.' || next == '-' || ('0' <= next  && next <= '9')){
     //Serial.println(".. a number");
     int i = start;

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/wyolum/jsonlib"
   },
-  "version": "0.1.1",
+  "version": "0.1.3",
   "framework": "arduino",
   "platforms": "*",
   "build": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=jsonlib
-version=0.1.2
+version=0.1.3
 author=Justin Shaw wyojustin@gmail.com
 maintainer=Justin Shaw wyojustin@gmail.com
 sentence=A simple JSON parsing library.


### PR DESCRIPTION
This pull request extends the jsonlib to include the boolean and null data types. 
Here this means: the types can be read, but the results "true", "false" and "null" are returned as a string.

The types correspond to the JSON definition at https://en.wikipedia.org/wiki/JSON#Data_types