### PR TITLE
Add missing comma to library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonlib",
-  "description": "Simple JSON parsing library for arduino"
+  "description": "Simple JSON parsing library for arduino",
   "keywords": "json arduino",
   "authors": {
     "name": "Justin Shaw",


### PR DESCRIPTION
I am extending the ESP32cam project, which utilizes your library - but I couldn't get it to work through the PlatformIO library manager.

Turns out, there was a comma missing in the library.json manifest file, which prevented the library manager in PlatformIO from using this project. Here's the fix!

Thanks! Best, Thomas
